### PR TITLE
feat: Place build information first in detect_GPU scripts output

### DIFF
--- a/jax_detect_GPU.py
+++ b/jax_detect_GPU.py
@@ -5,9 +5,8 @@ if __name__ == "__main__":
     xla_backend_type = xla_bridge.get_backend().platform  # cpu, gpu, tpu
     print(f"XLA backend type: {xla_backend_type}")
 
-    print(
-        f"\nNumber of {xla_backend_type.upper()}s found on system: {xla_bridge.device_count()}"
-    )
+    gpu_count = xla_bridge.device_count() if xla_backend_type == "gpu" else 0
+    print(f"\nNumber of GPUs found on system: {gpu_count}")
     if xla_backend_type == "gpu":
         for idx, device in enumerate(xla_backend.devices()):
             gpu_type = "Active GPU" if idx == 0 else "GPU"

--- a/jax_detect_GPU.py
+++ b/jax_detect_GPU.py
@@ -1,10 +1,10 @@
 from jax.lib import xla_bridge
 
 if __name__ == "__main__":
-    print(f"Number of GPUs found on system: {xla_bridge.device_count()}")
     xla_backend = xla_bridge.get_backend()
     xla_backend_type = xla_bridge.get_backend().platform  # cpu, gpu, tpu
     print(f"XLA backend type: {xla_backend_type}")
+    print(f"\nNumber of GPUs found on system: {xla_bridge.device_count()}")
     if xla_backend_type == "gpu":
         for idx, device in enumerate(xla_backend.devices()):
             gpu_type = "Active GPU" if idx == 0 else "GPU"

--- a/jax_detect_GPU.py
+++ b/jax_detect_GPU.py
@@ -5,7 +5,9 @@ if __name__ == "__main__":
     xla_backend_type = xla_bridge.get_backend().platform  # cpu, gpu, tpu
     print(f"XLA backend type: {xla_backend_type}")
 
-    print(f"\nNumber of GPUs found on system: {xla_bridge.device_count()}")
+    print(
+        f"\nNumber of {xla_backend_type.upper()}s found on system: {xla_bridge.device_count()}"
+    )
     if xla_backend_type == "gpu":
         for idx, device in enumerate(xla_backend.devices()):
             gpu_type = "Active GPU" if idx == 0 else "GPU"

--- a/jax_detect_GPU.py
+++ b/jax_detect_GPU.py
@@ -4,6 +4,7 @@ if __name__ == "__main__":
     xla_backend = xla_bridge.get_backend()
     xla_backend_type = xla_bridge.get_backend().platform  # cpu, gpu, tpu
     print(f"XLA backend type: {xla_backend_type}")
+
     print(f"\nNumber of GPUs found on system: {xla_bridge.device_count()}")
     if xla_backend_type == "gpu":
         for idx, device in enumerate(xla_backend.devices()):

--- a/tf_detect_GPU.py
+++ b/tf_detect_GPU.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     # Getting device details now to avoid info stream later during prints
     gpu_details = [get_device_details(gpu) for gpu in gpu_devices]
 
-    print(f"TensorFlow build supports GPU: {tf.test.is_built_with_gpu_support()}")
+    print(f"\nTensorFlow build supports GPU: {tf.test.is_built_with_gpu_support()}")
     print(f"TensorFlow build supports XLA: {tf.test.is_built_with_xla()}")
     is_built_with_cuda = tf.test.is_built_with_cuda()
     print(f"TensorFlow build supports CUDA: {is_built_with_cuda}")

--- a/tf_detect_GPU.py
+++ b/tf_detect_GPU.py
@@ -6,7 +6,6 @@ if __name__ == "__main__":
     # Getting device details now to avoid info stream later during prints
     gpu_details = [get_device_details(gpu) for gpu in gpu_devices]
 
-    print(f"\nNumber of GPUs found on system: {len(gpu_devices)}")
     print(f"TensorFlow build supports GPU: {tf.test.is_built_with_gpu_support()}")
     print(f"TensorFlow build supports XLA: {tf.test.is_built_with_xla()}")
     is_built_with_cuda = tf.test.is_built_with_cuda()
@@ -17,6 +16,7 @@ if __name__ == "__main__":
         print(f"TensorFlow build CUDA version: {build_info['cuda_version']}")
         print(f"TensorFlow build cuDNN version: {build_info['cudnn_version']}")
 
+    print(f"\nNumber of GPUs found on system: {len(gpu_devices)}")
     for device, details in zip(gpu_devices, gpu_details):
         print(f"\nGPU: {device.name}")
         print(f"GPU index: {device.name.split(':')[-1]}")

--- a/torch_detect_GPU.py
+++ b/torch_detect_GPU.py
@@ -3,13 +3,13 @@ from torch import cuda
 
 if __name__ == "__main__":
     # c.f. https://chrisalbon.com/deep_learning/pytorch/basics/check_if_pytorch_is_using_gpu/
-    print(f"Number of GPUs found on system: {cuda.device_count()}")
+    print(f"PyTorch build CUDA version: {torch.version.cuda}")
+    print(f"PyTorch build cuDNN version: {torch.backends.cudnn.version()}")
+    print(f"PyTorch build NCCL version: {torch.cuda.nccl.version()}")
+    print(f"\nNumber of GPUs found on system: {cuda.device_count()}")
+
     is_gpu_available = cuda.is_available()
     print(f"PyTorch has active GPU: {is_gpu_available}")
     if is_gpu_available:
-        print(f"PyTorch build CUDA version: {torch.version.cuda}")
-        print(f"PyTorch build cuDNN version: {torch.backends.cudnn.version()}")
-        print(f"PyTorch build NCCL version: {torch.cuda.nccl.version()}")
-
         print(f"\nActive GPU index: {cuda.current_device()}")
         print(f"Active GPU name: {cuda.get_device_name(cuda.current_device())}")

--- a/torch_detect_GPU.py
+++ b/torch_detect_GPU.py
@@ -6,8 +6,8 @@ if __name__ == "__main__":
     print(f"PyTorch build CUDA version: {torch.version.cuda}")
     print(f"PyTorch build cuDNN version: {torch.backends.cudnn.version()}")
     print(f"PyTorch build NCCL version: {torch.cuda.nccl.version()}")
-    print(f"\nNumber of GPUs found on system: {cuda.device_count()}")
 
+    print(f"\nNumber of GPUs found on system: {cuda.device_count()}")
     is_gpu_available = cuda.is_available()
     print(f"PyTorch has active GPU: {is_gpu_available}")
     if is_gpu_available:


### PR DESCRIPTION
First give the information on the library build and then give information on the GPUs available

```
* Make library build information the first output given from the detect_GPU test scripts
```